### PR TITLE
Add support for exponentials in json numbers.

### DIFF
--- a/test/jsonstream_test.py
+++ b/test/jsonstream_test.py
@@ -36,6 +36,20 @@ def test_single_float_value():
         ((), 3.14),
     ]
 
+def test_exponential_float_values():
+    assert _jsonstream('3.14e10') == [
+        ((), 3.14e10),
+    ]
+    assert _jsonstream('-3.14e10') == [
+        ((), -3.14e10),
+    ]
+    assert _jsonstream('-3.14e+10') == [
+        ((), -3.14e+10),
+    ]
+    assert _jsonstream('-3E-10') == [
+        ((), -3E-10),
+    ]
+
 
 def test_single_string_value():
     assert _jsonstream('"foo"') == [


### PR DESCRIPTION
Fixes https://github.com/nigelsmall/httpstream/issues/5

FYI this isn't just an enhancement, it's part of the spec. (Although under what conditions numbers should be returned as floats or integers and with what precision is the weak bit of the spec.) Also have you seen https://github.com/isagalaev/ijson ? Well, anyway, I was running the related issue py2neo and the fix was reasonably simple so here you go.
